### PR TITLE
Recover TCP sessions.

### DIFF
--- a/src/datagram.c
+++ b/src/datagram.c
@@ -118,7 +118,7 @@ const char *get_cmd_name(uint8_t cmd)
 	return "UNKNOWN_CMD";
 }
 
-void tnfs_sockinit()
+void tnfs_sockinit(int port)
 {
 	struct sockaddr_in servaddr;
 
@@ -137,7 +137,7 @@ void tnfs_sockinit()
 	memset(&servaddr, 0, sizeof(servaddr));
 	servaddr.sin_family = AF_INET;
 	servaddr.sin_addr.s_addr = htons(INADDR_ANY);
-	servaddr.sin_port = htons(TNFSD_PORT);
+	servaddr.sin_port = htons(port);
 
 	if (bind(sockfd, (struct sockaddr *)&servaddr, sizeof(servaddr)) < 0)
 		die("Unable to bind");
@@ -157,7 +157,7 @@ void tnfs_sockinit()
 	memset(&servaddr, 0, sizeof(servaddr));
 	servaddr.sin_family = AF_INET;
 	servaddr.sin_addr.s_addr = htons(INADDR_ANY);
-	servaddr.sin_port = htons(TNFSD_PORT);
+	servaddr.sin_port = htons(port);
 	if (bind(tcplistenfd, (struct sockaddr *)&servaddr,
 			 sizeof(servaddr)) < 0)
 	{

--- a/src/datagram.h
+++ b/src/datagram.h
@@ -55,7 +55,7 @@ typedef struct _tcp_conn
 } TcpConnection;
 
 /* Handle the socket interface */
-void tnfs_sockinit();
+void tnfs_sockinit(int port);
 void tnfs_mainloop();
 void tnfs_handle_udpmsg();
 void tcp_accept(TcpConnection *tcp_conn_list);

--- a/src/session.c
+++ b/src/session.c
@@ -319,7 +319,7 @@ Session *tnfs_findsession_ipaddr(in_addr_t ipaddr, int *sindex)
 	return NULL;
 }
 
-void tnfs_removesession_by_cli_fd(int cli_fd)
+void tnfs_reset_cli_fd_in_sessions(int cli_fd)
 {
 	int i;
 	Session *s;
@@ -331,8 +331,8 @@ void tnfs_removesession_by_cli_fd(int cli_fd)
 			s = slist[i];
 			if (s->cli_fd == cli_fd)
 			{
-				LOG("Deleting disconnected session 0x%02x\n", s->sid);
-				tnfs_freesession(s, i);
+				LOG("Removing TCP connection handle from session 0x%02x\n", s->sid);
+				s->cli_fd = 0;
 			}
 		}
 	}

--- a/src/session.c
+++ b/src/session.c
@@ -291,7 +291,9 @@ Session *tnfs_findsession_ipaddr(in_addr_t ipaddr, int *sindex)
 			s = slist[i];
 
 			/* Remove expired sessions while we're looking at them all */
-			if(SESSION_TIMEOUT > 0 && (currenttime - s->last_contact >= SESSION_TIMEOUT))
+			if(SESSION_TIMEOUT > 0 &&
+				(currenttime - s->last_contact >= SESSION_TIMEOUT) &&
+				s->cli_fd == 0)
 			{
 				LOG("Deleting expired session 0x%02x\n", s->sid);
 				tnfs_freesession(s, i);

--- a/src/session.h
+++ b/src/session.h
@@ -46,7 +46,7 @@ Session *tnfs_allocsession(int *sindex, uint16_t withSid);
 void tnfs_freesession(Session *s, int sindex);
 Session *tnfs_findsession_sid(uint16_t sid, int *sindex);
 Session *tnfs_findsession_ipaddr(in_addr_t ipaddr, int *sindex);
-void tnfs_removesession_by_cli_fd(int cli_fd);
+void tnfs_reset_cli_fd_in_sessions(int cli_fd);
 uint16_t tnfs_newsid();
 
 

--- a/src/tnfs_file.c
+++ b/src/tnfs_file.c
@@ -424,7 +424,8 @@ int validate_fd(Header *hdr, Session *s, unsigned char *buf, int bufsz,
 				int propersize)
 {
 	if (bufsz < propersize ||
-		*buf > MAX_FD_PER_CONN)
+		*buf > MAX_FD_PER_CONN ||
+		s->fd[*buf] == 0)
 	{
 #ifdef DEBUG
 		fprintf(stderr, "BAD FD: bufsz=%d propersize=%d fd=%d max=%d",


### PR DESCRIPTION
With this PR, sessions assigned to a disconnected TCP socket are no longer removed and can be re-attached if the client connects again from the same IP and provides the same session id.