### PR TITLE
Fixed warnings under Ubuntu 20 and 22

### DIFF
--- a/src/directory.c
+++ b/src/directory.c
@@ -803,6 +803,7 @@ int _load_directory(dir_handle *dirh, uint8_t diropts, uint8_t sortopts, uint16_
 {
 	struct dirent *entry;
 	char statpath[MAX_TNFSPATH];
+	char temp_statpath[MAX_TNFSPATH*2];
 
 	// Free any existing entries
 	dirlist_free(dirh->entry_list);
@@ -822,7 +823,8 @@ int _load_directory(dir_handle *dirh, uint8_t diropts, uint8_t sortopts, uint16_
 	{
 		// Try to stat the file before we can decide on other things
 		fileinfo_t finf;
-		snprintf(statpath, sizeof(statpath), "%s%c%s", dirh->path, FILEINFO_PATHSEPARATOR, entry->d_name);
+		snprintf(temp_statpath, sizeof(temp_statpath), "%s%c%s", dirh->path, FILEINFO_PATHSEPARATOR, entry->d_name);
+		strncpy(statpath, temp_statpath, sizeof(statpath));
 		if (get_fileinfo(statpath, &finf) == 0)
 		{
 			/* If it's not a directory and we have a pattern that this doesn't match, skip it

--- a/src/tnfs.h
+++ b/src/tnfs.h
@@ -46,7 +46,7 @@
 #endif
 
 #ifndef socklen_t
-#define socklen_t int32_t
+#define socklen_t uint32_t
 #endif
 
 #include "config.h"


### PR DESCRIPTION
datagram.c: In function ‘tcp_accept’:
datagram.c:264:67: warning: pointer targets in passing argument 3 of ‘accept’ differ in signedness [-Wpointer-sign]
  264 |         acc_fd = accept(tcplistenfd, (struct sockaddr *)&cliaddr, &cli_len);
      |                                                                   ^~~~~~~~
      |                                                                   |
      |                                                                   int32_t * {aka int *}
In file included from datagram.c:36:
/usr/include/x86_64-linux-gnu/sys/socket.h:307:42: note: expected ‘socklen_t * restrict’ {aka ‘unsigned int * restrict’} but argument is of type ‘int32_t *’ {aka ‘int *’}
  307 |                    socklen_t *__restrict __addr_len);
      |                    ~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~
datagram.c: In function ‘tnfs_handle_udpmsg’:
datagram.c:310:73: warning: pointer targets in passing argument 6 of ‘recvfrom’ differ in signedness [-Wpointer-sign]
  310 |                                            (struct sockaddr *)&cliaddr, &len);
      |                                                                         ^~~~
      |                                                                         |
      |                                                                         int32_t * {aka int *}
In file included from datagram.c:36:
/usr/include/x86_64-linux-gnu/sys/socket.h:165:48: note: expected ‘socklen_t * restrict’ {aka ‘unsigned int * restrict’} but argument is of type ‘int32_t *’ {aka ‘int *’}
  165 |                          socklen_t *__restrict __addr_len);
      |                          ~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~

directory.c: In function ‘_load_directory’:
directory.c:825:59: warning: ‘%s’ directive output may be truncated writing up to 255 bytes into a region of size between 0 and 255 [-Wformat-truncation=]
  825 |                 snprintf(statpath, sizeof(statpath), "%s%c%s", dirh->path, FILEINFO_PATHSEPARATOR, entry->d_name);
      |                                                           ^~
directory.c:825:17: note: ‘snprintf’ output between 2 and 512 bytes into a destination of size 256
  825 |                 snprintf(statpath, sizeof(statpath), "%s%c%s", dirh->path, FILEINFO_PATHSEPARATOR, entry->d_name);
      |                 ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~