### PR TITLE
Support optional read-only mode.

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -32,7 +32,7 @@ ifdef USAGELOG
 endif
 
 CFLAGS=$(FLAGS) $(EXFLAGS) $(LOGFLAGS)
-OBJS=main.o datagram.o event_common.o log.o session.o endian.o directory.o errortable.o tnfs_file.o chroot.o fileinfo.o stats.o $(EXOBJS)
+OBJS=main.o datagram.o event_common.o log.o session.o endian.o directory.o errortable.o tnfs_file.o chroot.o fileinfo.o stats.o auth.o $(EXOBJS)
 
 all:	$(OBJS)
 	$(CC) -o ../bin/$(EXEC) $(OBJS) $(LIBS)

--- a/src/auth.c
+++ b/src/auth.c
@@ -1,0 +1,54 @@
+#include "auth.h"
+#include "tnfs.h"
+#include "tnfs_file.h"
+
+int RW_CMDS[] =
+{
+    TNFS_MKDIR,
+    TNFS_RMDIR,
+    TNFS_WRITEBLOCK,
+    TNFS_UNLINKFILE,
+    TNFS_CHMODFILE,
+    TNFS_RENAMEFILE,
+    -1,
+};
+
+int RW_FLAGS =
+    TNFS_O_WRONLY |
+    TNFS_O_RDWR   |
+    TNFS_O_APPEND |
+    TNFS_O_CREAT  |
+    TNFS_O_TRUNC  |
+    TNFS_O_EXCL;
+
+bool read_only;
+
+void auth_init(bool _read_only)
+{
+    read_only = _read_only;
+}
+
+bool is_cmd_allowed(uint8_t cmd)
+{
+    if (!read_only)
+    {
+        return true;
+    }
+    for (int i = 0; RW_CMDS[i] != -1; i++)
+    {
+        if (RW_CMDS[i] == cmd)
+        {
+            return false;
+        }
+    }
+    return true;
+}
+
+bool is_open_allowed(char *filename, int flags)
+{
+    if (!read_only)
+    {
+        return true;
+    }
+    return (flags & RW_FLAGS) == 0;
+}

--- a/src/auth.h
+++ b/src/auth.h
@@ -1,0 +1,13 @@
+#ifndef _READONLY_H
+#define _READONLY_H
+
+#include <stdint.h>
+#include <stdbool.h>
+
+void auth_init(bool enable_writes);
+
+bool is_cmd_allowed(uint8_t cmd);
+
+bool is_open_allowed(char *filename, int flags);
+
+#endif

--- a/src/datagram.h
+++ b/src/datagram.h
@@ -54,6 +54,7 @@ void tnfs_decode(struct sockaddr_in *cliaddr, int cli_fd,
 	int rxbytes, unsigned char *rxbuf);
 void tnfs_invalidsession(Header *hdr);
 void tnfs_badcommand(Header *hdr, Session *sess);
+void tnfs_notpermitted(Header *hdr);
 void tnfs_send(Session *sess, Header *hdr, unsigned char *msg, int msgsz);
 void tnfs_resend(Session *sess, struct sockaddr_in *cliaddr, int cli_fd);
 #endif


### PR DESCRIPTION
This PR adds support for the read-only mode, in which all mutating operations are forbidden. The read-only mode can be enabled with the `-r` switch:

```
./tnfsd -r /data
```