### PR TITLE
set TCP keepalive and remove related sessions when client disconnects

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 /tnfsd
 /tnfsd.exe
 bin/tnfsd.exe
+/data

--- a/src/Makefile
+++ b/src/Makefile
@@ -17,7 +17,7 @@ ifeq ($(OS),Windows_NT)
     EXEC = tnfsd.exe
 endif
 ifeq ($(OS),BSD)
-    FLAGS = -Wall -DUNIX -DENABLE_CHROOT -DNEED_ERRTABLE
+    FLAGS = -Wall -DUNIX -DENABLE_CHROOT -DNEED_ERRTABLE -DBSD
     EXOBJS = event_kqueue.o
     LIBS =
     EXEC = tnfsd

--- a/src/config.h
+++ b/src/config.h
@@ -15,8 +15,7 @@
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
  * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  *
@@ -42,5 +41,8 @@
 #define MAX_FILENAME_LEN 256	/* longest filename supported */
 #define MAX_IOSZ	512	/* maximum size of an IO operation */
 #define STATS_INTERVAL 60   /* how often the server stats should be logged. 0 to disable stats logging. */
+#define TCP_KA_IDLE 30 /* the time (in seconds) the connection needs to remain idle before TCP starts sending keepalive probes */
+#define TCP_KA_INTVL 1  /* the time (in seconds) between individual keepalive probes */
+#define TCP_KA_COUNT 60 /* the maximum number of keepalive probes TCP should send before dropping the connection */
 
 #endif

--- a/src/session.c
+++ b/src/session.c
@@ -334,6 +334,7 @@ void tnfs_reset_cli_fd_in_sessions(int cli_fd)
 			if (s->cli_fd == cli_fd)
 			{
 				LOG("Removing TCP connection handle from session 0x%02x\n", s->sid);
+            tnfs_freesession(s, i);
 				s->cli_fd = 0;
 			}
 		}


### PR DESCRIPTION
Hi,
I propose these changes to implement TCP_KEEPALIVE socket options on TNFS server side to avoid stale sockets.
When a socket is expired all related sessions are deallocated. I set keepalive parameters to some values but they can be set in src/config.h file.