### PR TITLE
Close stale TCP connections after 10 minutes

### DIFF
--- a/src/config.h
+++ b/src/config.h
@@ -28,7 +28,7 @@
 #define MAX_SESSIONS        4096   /* maximum number of opened sessions */
 #define MAX_SESSIONS_PER_IP 4096   /* maximum number of sessions from a single IP */
 #define MAX_TCP_CONN        4096   /* maximum number of TCP connections */
-#define SESSION_TIMEOUT 21600 /* Sessions are thrown out after no contact for this many seconds. 0 = no timeout */
+#define SESSION_TIMEOUT 600 /* Sessions are thrown out after no contact for this many seconds. 0 = no timeout */
 #define CONN_TIMEOUT    600 /* TCP connections are thrown out after no contact for this many seconds. 0 = no timeout */
 #define TNFS_HEADERSZ	4	/* minimum header size */
 #define TNFS_MAX_PAYLOAD (MAXMSGSZ - TNFS_HEADERSZ - 1) /* Maximum usuable payload in a UDP datagram (-1 for status byte) */

--- a/src/config.h
+++ b/src/config.h
@@ -29,6 +29,7 @@
 #define MAX_SESSIONS_PER_IP 4096   /* maximum number of sessions from a single IP */
 #define MAX_TCP_CONN        4096   /* maximum number of TCP connections */
 #define SESSION_TIMEOUT 21600 /* Sessions are thrown out after no contact for this many seconds. 0 = no timeout */
+#define CONN_TIMEOUT    600 /* TCP connections are thrown out after no contact for this many seconds. 0 = no timeout */
 #define TNFS_HEADERSZ	4	/* minimum header size */
 #define TNFS_MAX_PAYLOAD (MAXMSGSZ - TNFS_HEADERSZ - 1) /* Maximum usuable payload in a UDP datagram (-1 for status byte) */
 #define MAX_TNFSPATH	256	/* maximum path length */

--- a/src/datagram.h
+++ b/src/datagram.h
@@ -57,4 +57,6 @@ void tnfs_badcommand(Header *hdr, Session *sess);
 void tnfs_notpermitted(Header *hdr);
 void tnfs_send(Session *sess, Header *hdr, unsigned char *msg, int msgsz);
 void tnfs_resend(Session *sess, struct sockaddr_in *cliaddr, int cli_fd);
+void tnfs_close_stale_connections(TcpConnection *tcp_conn_list);
+void tnfs_close_tcp(TcpConnection *tcp_conn);
 #endif

--- a/src/tnfs.h
+++ b/src/tnfs.h
@@ -157,6 +157,7 @@ typedef struct _tcp_conn
 {
 	struct sockaddr_in cliaddr;  /* client address */
 	int cli_fd;					 /* FD for the TCP connection */
+	time_t last_contact;         /* timestamp of last received request */
 } TcpConnection;
 
 #endif


### PR DESCRIPTION
This PR introduces a timeout for the inactive TCP connections. The timeout is 10 minutes, which should be fine, since firmware sends a keep-alive packet every 1 minute:

https://github.com/FujiNetWIFI/fujinet-firmware/blob/fb9e6cc7334225031a57e293309d8612a21cc74b/lib/FileSystem/fnFsTNFS.cpp#L128-L129

Also, it reduces the session timeout (affecting TCP and UDP clients) from 6 hours to 10 minutes (since the keep-alive should refresh sessions as well, regardless of the protocol).