### PR TITLE
README: add download and setup instruction links

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,12 @@
 # TNFS - The Trivial Network Filesystem
 
+## Latest Release
+See [Releases](https://github.com/FujiNetWIFI/tnfsd/releases) to download the most recent pre-compiled versions of the TNFS daemon.
+
+## Setup Instructions
+
+For instructions on running a TNFS server locally, see [Setting up a TNFS Server](https://github.com/FujiNetWIFI/fujinet-firmware/wiki/Setting-up-a-TNFS-Server) on the main Wiki.
+
 ## Rationale
 
 Protocols such as NFS (Unix) or SMB (Windows) are overly complex for 8 bit


### PR DESCRIPTION
If someone finds their way to this repo instead of coming from https://fujinet.online/download/ it would probably avoid some confusion to directly call out there's a pre-compiled binary that you just have to run, and to link to the instructions in the other wiki.