### PR TITLE
Introduce new tnfsd.c file controlling the server lifecycle.

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -5,19 +5,19 @@ ifndef OS
 endif
 
 ifeq ($(OS),LINUX)
-    FLAGS = -Wall -DUNIX -DNEED_BSDCOMPAT -DENABLE_CHROOT -DNEED_ERRTABLE
+    FLAGS = -Wall -DUNIX -DNEED_BSDCOMPAT -DENABLE_CHROOT 
     EXOBJS = strlcpy.o strlcat.o event_epoll.o 
     LIBS =
     EXEC = tnfsd
 endif
 ifeq ($(OS),Windows_NT)
-    FLAGS = -Wall -DWIN32 -DNEED_ERRTABLE -DNEED_BSDCOMPAT
+    FLAGS = -Wall -DWIN32 -DNEED_BSDCOMPAT
     EXOBJS = strlcpy.o strlcat.o event_select.o 
     LIBS = -lwsock32
     EXEC = tnfsd.exe
 endif
 ifeq ($(OS),BSD)
-    FLAGS = -Wall -DUNIX -DENABLE_CHROOT -DNEED_ERRTABLE -DBSD
+    FLAGS = -Wall -DUNIX -DBSD -DENABLE_CHROOT
     EXOBJS = event_kqueue.o
     LIBS =
     EXEC = tnfsd
@@ -31,8 +31,8 @@ ifdef USAGELOG
     LOGFLAGS = -DUSAGELOG
 endif
 
-CFLAGS=$(FLAGS) $(EXFLAGS) $(LOGFLAGS)
-OBJS=main.o datagram.o event_common.o log.o session.o endian.o directory.o errortable.o tnfs_file.o chroot.o fileinfo.o stats.o auth.o $(EXOBJS)
+CFLAGS=$(FLAGS) $(EXFLAGS) $(LOGFLAGS) -DNEED_ERRTABLE
+OBJS=main.o datagram.o event_common.o log.o session.o endian.o directory.o errortable.o tnfs_file.o chroot.o fileinfo.o stats.o auth.o tnfsd.o $(EXOBJS)
 
 all:	$(OBJS)
 	$(CC) -o ../bin/$(EXEC) $(OBJS) $(LIBS)

--- a/src/datagram.c
+++ b/src/datagram.c
@@ -567,7 +567,8 @@ void tnfs_send(Session *sess, Header *hdr, unsigned char *msg, int msgsz)
 	// TNFS_HEADERSZ + statuscode + msg
 	if (TNFS_HEADERSZ + 1 + msgsz > MAXMSGSZ)
 	{
-		die("tnfs_send: Message too big");
+		LOG("tnfs_send: Message too big");
+		return;
 	}
 
 	cliaddr.sin_family = AF_INET;

--- a/src/datagram.h
+++ b/src/datagram.h
@@ -45,7 +45,8 @@
 #include "tnfs.h"
 
 /* Handle the socket interface */
-void tnfs_sockinit(int port);
+int tnfs_sockinit(int port);
+void tnfs_sockclose();
 void tnfs_mainloop();
 void tnfs_handle_udpmsg();
 void tcp_accept(TcpConnection *tcp_conn_list);
@@ -58,5 +59,6 @@ void tnfs_notpermitted(Header *hdr);
 void tnfs_send(Session *sess, Header *hdr, unsigned char *msg, int msgsz);
 void tnfs_resend(Session *sess, struct sockaddr_in *cliaddr, int cli_fd);
 void tnfs_close_stale_connections(TcpConnection *tcp_conn_list);
+void tnfs_close_all_connections(TcpConnection *tcp_conn_list);
 void tnfs_close_tcp(TcpConnection *tcp_conn);
 #endif

--- a/src/directory.c
+++ b/src/directory.c
@@ -111,7 +111,7 @@ char root[MAX_ROOT]; /* root for all operations */
 char realroot[MAX_ROOT]; /* full path of the tnfs root dir */
 char dirbuf[MAX_FILEPATH];
 
-int tnfs_setroot(char *rootdir)
+int tnfs_setroot(const char *rootdir)
 {
 	if (strlen(rootdir) > MAX_ROOT)
 		return -1;

--- a/src/directory.h
+++ b/src/directory.h
@@ -43,7 +43,7 @@
 #define TNFS_DIRSTATUS_EOF 0x01
 
 /* initialize and set the root dir */
-int tnfs_setroot(char *rootdir);
+int tnfs_setroot(const char *rootdir);
 
 /* validates a path points to an actual directory */
 int validate_dir(Session *s, const char *path);

--- a/src/event_epoll.c
+++ b/src/event_epoll.c
@@ -22,7 +22,7 @@ bool tnfs_event_register(int fd)
 {
     struct epoll_event ev;
     ev.events = EPOLLIN | EPOLLET | EPOLLRDHUP;
-	ev.data.fd = fd;
+    ev.data.fd = fd;
 
     if (epoll_ctl(epfd, EPOLL_CTL_ADD, fd, &ev) == -1)
     {

--- a/src/event_epoll.c
+++ b/src/event_epoll.c
@@ -14,8 +14,8 @@ event_wait_res_t wait_result;
 
 void tnfs_event_init()
 {
-    epfd = epoll_create(1);
     wait_result.fds = calloc(_EVENT_MAX_FDS, sizeof(int));
+    epfd = epoll_create(1);
 }
 
 bool tnfs_event_register(int fd)
@@ -46,7 +46,6 @@ event_wait_res_t* tnfs_event_wait(int timeout_sec)
 
     if (readyfds == -1)
     {
-        LOG("tnfs_event_wait: epoll_wait failed\n");
         wait_result.size = -1;
         return &wait_result;
     }
@@ -63,4 +62,5 @@ event_wait_res_t* tnfs_event_wait(int timeout_sec)
 void tnfs_event_close()
 {
     close(epfd);
+    free(wait_result.fds);
 }

--- a/src/event_kqueue.c
+++ b/src/event_kqueue.c
@@ -15,8 +15,8 @@ event_wait_res_t wait_result;
 
 void tnfs_event_init()
 {
-    kq = kqueue();
     wait_result.fds = calloc(_EVENT_MAX_FDS, sizeof(int));
+    kq = kqueue();
 }
 
 bool tnfs_event_register(int fd)
@@ -49,7 +49,6 @@ event_wait_res_t* tnfs_event_wait(int timeout_sec)
 
     if (readyfds == -1)
     {
-        LOG("tnfs_event_wait: kevent failed\n");
         wait_result.size = -1;
         return &wait_result;
     }
@@ -65,4 +64,5 @@ event_wait_res_t* tnfs_event_wait(int timeout_sec)
 void tnfs_event_close()
 {
     close(kq);
+    free(wait_result.fds);
 }

--- a/src/event_select.c
+++ b/src/event_select.c
@@ -74,7 +74,6 @@ event_wait_res_t* tnfs_event_wait(int timeout_sec)
 
     if (readyfds == SOCKET_ERROR)
     {
-        LOG("tnfs_event_wait: select failed\n");
         wait_result.size = SOCKET_ERROR;
         return &wait_result;
     }
@@ -96,5 +95,5 @@ event_wait_res_t* tnfs_event_wait(int timeout_sec)
 
 void tnfs_event_close()
 {
-    // do nothing
+    free(wait_result.fds);
 }

--- a/src/log.c
+++ b/src/log.c
@@ -24,21 +24,14 @@
  *
  * */
 
-#include <stdio.h>
 #include <time.h>
 #include <stdlib.h>
-#include <stdarg.h>
 #include <sys/types.h>
 
 #include "log.h"
 #include "tnfs.h"
 
-void die(const char *msg)
-{
-	log_time();
-	fprintf(stderr, "%s\n", msg);
-	exit(-1);
-}
+FILE *output;
 
 void TNFSMSGLOG(Header *hdr, const char *msg, ...)
 {
@@ -53,10 +46,10 @@ void TNFSMSGLOG(Header *hdr, const char *msg, ...)
 	vsnprintf(buff, sizeof(buff), msg, vargs);
 	va_end(vargs);
 
-	fprintf(stderr, "%d.%d.%d.%d s=%02x c=%02x q=%02x | %s\n", ip[0], ip[1], ip[2], ip[3], hdr->sid, hdr->cmd, hdr->seqno, buff);
+	fprintf(output, "%d.%d.%d.%d s=%02x c=%02x q=%02x | %s\n", ip[0], ip[1], ip[2], ip[3], hdr->sid, hdr->cmd, hdr->seqno, buff);
 
 #ifdef WIN32
-	fflush(stderr);
+	fflush(output);
 #endif
 }
 
@@ -80,10 +73,10 @@ void USGLOG(Header *hdr, const char *msg, ...)
 	vsnprintf(buff, sizeof(buff), msg, vargs);
 	va_end(vargs);
 
-	fprintf(stderr, "%s|%d.%d.%d.%d|SID=%02x|%s\n", sdate, ip[0], ip[1], ip[2], ip[3], hdr->sid, buff);
+	fprintf(output, "%s|%d.%d.%d.%d|SID=%02x|%s\n", sdate, ip[0], ip[1], ip[2], ip[3], hdr->sid, buff);
 
 #ifdef WIN32
-	fflush(stderr);
+	fflush(output);
 #endif
 }
 
@@ -100,10 +93,10 @@ void MSGLOG(in_addr_t ipaddr, const char *msg, ...)
 	vsnprintf(buff, sizeof(buff), msg, vargs);
 	va_end(vargs);
 
-	fprintf(stderr, "%d.%d.%d.%d | %s\n", ip[0], ip[1], ip[2], ip[3], buff);
+	fprintf(output, "%d.%d.%d.%d | %s\n", ip[0], ip[1], ip[2], ip[3], buff);
 
 #ifdef WIN32
-	fflush(stderr);
+	fflush(output);
 #endif
 }
 
@@ -114,11 +107,11 @@ void LOG(const char *msg, ...)
 	va_list vargs;
 	va_start(vargs, msg);
 
-	vfprintf(stderr, msg, vargs);
+	vfprintf(output, msg, vargs);
 	va_end(vargs);
 
 #ifdef WIN32
-	fflush(stderr);
+	fflush(output);
 #endif
 }
 
@@ -129,16 +122,21 @@ void log_time() {
     time(&now);
     gmt = gmtime(&now);
     if (gmt == NULL) {
-        fprintf(stderr, "Failed to convert time to GMT.\n");
+        fprintf(output, "Failed to convert time to GMT.\n");
         return;
     }
 
     char formatted_time[sizeof "2011-10-08T07:07:09Z"];
     // Replace %F and %T with equivalents for broader compatibility (wasn't working in MinGW)
     if (strftime(formatted_time, sizeof formatted_time, "%Y-%m-%dT%H:%M:%SZ", gmt) == 0) {
-        fprintf(stderr, "[??] ");
+        fprintf(output, "[??] ");
         return;
     }
 
-    fprintf(stderr, "[%s] ", formatted_time);
+    fprintf(output, "[%s] ", formatted_time);
+}
+
+void log_init(FILE *log_output)
+{
+	output = log_output;
 }

--- a/src/log.c
+++ b/src/log.c
@@ -47,10 +47,7 @@ void TNFSMSGLOG(Header *hdr, const char *msg, ...)
 	va_end(vargs);
 
 	fprintf(output, "%d.%d.%d.%d s=%02x c=%02x q=%02x | %s\n", ip[0], ip[1], ip[2], ip[3], hdr->sid, hdr->cmd, hdr->seqno, buff);
-
-#ifdef WIN32
 	fflush(output);
-#endif
 }
 
 void USGLOG(Header *hdr, const char *msg, ...)
@@ -74,10 +71,7 @@ void USGLOG(Header *hdr, const char *msg, ...)
 	va_end(vargs);
 
 	fprintf(output, "%s|%d.%d.%d.%d|SID=%02x|%s\n", sdate, ip[0], ip[1], ip[2], ip[3], hdr->sid, buff);
-
-#ifdef WIN32
 	fflush(output);
-#endif
 }
 
 void MSGLOG(in_addr_t ipaddr, const char *msg, ...)
@@ -94,10 +88,7 @@ void MSGLOG(in_addr_t ipaddr, const char *msg, ...)
 	va_end(vargs);
 
 	fprintf(output, "%d.%d.%d.%d | %s\n", ip[0], ip[1], ip[2], ip[3], buff);
-
-#ifdef WIN32
 	fflush(output);
-#endif
 }
 
 void LOG(const char *msg, ...)
@@ -109,10 +100,7 @@ void LOG(const char *msg, ...)
 
 	vfprintf(output, msg, vargs);
 	va_end(vargs);
-
-#ifdef WIN32
 	fflush(output);
-#endif
 }
 
 void log_time() {

--- a/src/log.h
+++ b/src/log.h
@@ -26,12 +26,11 @@
  *
  * */
 #include <stdarg.h>
+#include <stdio.h>
 
 #include "tnfs.h"
 
-/* Log a message and exit */
-void die(const char *msg);
-
+void log_init(FILE *file);
 void TNFSMSGLOG(Header *hdr, const char *msg, ...);
 void USGLOG(Header *hdr, const char *msg, ...);
 void MSGLOG(in_addr_t ipaddr, const char *msg, ...);

--- a/src/main.c
+++ b/src/main.c
@@ -133,6 +133,7 @@ int main(int argc, char **argv)
     }
 
     tnfsd_init();
+    tnfsd_init_logs(STDERR_FILENO);
     signal(SIGINT, tnfsd_stop);
     tnfsd_start(root_path, port, read_only);
 

--- a/src/main.c
+++ b/src/main.c
@@ -107,7 +107,7 @@ int main(int argc, char **argv)
             LOG("chroot group required\n");
             exit(-1);
         }
-	    LOG("tnfsd will be jailed at %s\n", argv[optind]);
+        LOG("tnfsd will be jailed at %s\n", argv[optind]);
         chroot_tnfs(uvalue, gvalue, argv[optind]);
         root_path = strdup("/");
     }
@@ -137,5 +137,5 @@ int main(int argc, char **argv)
     signal(SIGINT, tnfsd_stop);
     tnfsd_start(root_path, port, read_only);
 
-	return 0;
+    return 0;
 }

--- a/src/session.c
+++ b/src/session.c
@@ -339,7 +339,6 @@ void tnfs_reset_cli_fd_in_sessions(int cli_fd)
 			if (s->cli_fd == cli_fd)
 			{
 				LOG("Removing TCP connection handle from session 0x%02x\n", s->sid);
-            			// tnfs_freesession(s, i); // commented out for now.
 				s->cli_fd = 0;
 			}
 		}

--- a/src/session.c
+++ b/src/session.c
@@ -202,6 +202,11 @@ Session *tnfs_allocsession(int *sindex, uint16_t withSid)
 				else
 				{
 					s->sid = tnfs_newsid();
+					if (s->sid == 0)
+					{
+						LOG("Can't allocate session");
+						return NULL;
+					}
 				}
 				LOG("Allocated new session for 0x%02x\n", s->sid);
 				slist[*sindex] = s;
@@ -358,7 +363,7 @@ uint16_t tnfs_newsid()
 		if (!tnfs_findsession_sid(newsid, &sindex))
 			return newsid;
 	}
-	die("Tried to find a new SID 256 times. (Broken PRNG)");
+	LOG("Tried to find a new SID 256 times. (Broken PRNG)");
 	return 0;
 }
 

--- a/src/tnfsd.c
+++ b/src/tnfsd.c
@@ -1,8 +1,11 @@
+#include <stdio.h>
+
 #include "auth.h"
 #include "datagram.h"
 #include "directory.h"
 #include "errortable.h"
 #include "event.h"
+#include "log.h"
 #include "version.h"
 #include "tnfsd.h"
 
@@ -10,6 +13,12 @@ void tnfsd_init()
 {
 	tnfs_init();              /* initialize structures etc. */
 	tnfs_init_errtable();     /* initialize error lookup table */
+}
+
+void tnfsd_init_logs(int log_output_fd)
+{
+    FILE* log_output = fdopen(log_output_fd, "w");
+    log_init(log_output);
 }
 
 int tnfsd_start(const char* path, int port, bool read_only)

--- a/src/tnfsd.c
+++ b/src/tnfsd.c
@@ -17,41 +17,41 @@ void tnfsd_init()
 
 void tnfsd_init_logs(int log_output_fd)
 {
-    FILE* log_output = fdopen(log_output_fd, "w");
-    log_init(log_output);
+	FILE* log_output = fdopen(log_output_fd, "w");
+	log_init(log_output);
 }
 
 int tnfsd_start(const char* path, int port, bool read_only)
 {
 	LOG("Starting tnfsd version %s on port %d using root directory \"%s\"\n", version, port, path);
-    if (read_only)
-    {
-        LOG("The server runs in read-only mode. TNFS clients can only list and download files.\n");
-    }
-    else
-    {
-        LOG("The server runs in read-write mode. TNFS clients can upload and modify files. Use -r to enable read-only mode.\n");
-    }
+	if (read_only)
+	{
+		LOG("The server runs in read-only mode. TNFS clients can only list and download files.\n");
+	}
+	else
+	{
+		LOG("The server runs in read-write mode. TNFS clients can upload and modify files. Use -r to enable read-only mode.\n");
+	}
 
-    if (tnfs_setroot(path) < 0)
-    {
+	if (tnfs_setroot(path) < 0)
+	{
 		LOG("Invalid root directory: %s\n", path);
-        return TNFSD_ERR_INVALID_DIR;
-    }
+		return TNFSD_ERR_INVALID_DIR;
+	}
 	tnfs_event_init();        /* initialize event system */
 	if (tnfs_sockinit(port) < 0)  /* initialize communications */
-    {
-        LOG("Can't bind port %d\n", port);
-        return TNFSD_ERR_SOCKET_ERROR;
-    }      
+	{
+		LOG("Can't bind port %d\n", port);
+		return TNFSD_ERR_SOCKET_ERROR;
+	}      
 	auth_init(read_only);     /* initialize authentication */
 	tnfs_mainloop();          /* run */
-    tnfs_event_close();
-    return 0;
+	tnfs_event_close();
+	return 0;
 }
 
 void tnfsd_stop()
 {
-    LOG("Stopping tnfsd server.\n");
-    tnfs_sockclose();
+	LOG("Stopping tnfsd server.\n");
+	tnfs_sockclose();
 }

--- a/src/tnfsd.c
+++ b/src/tnfsd.c
@@ -1,0 +1,48 @@
+#include "auth.h"
+#include "datagram.h"
+#include "directory.h"
+#include "errortable.h"
+#include "event.h"
+#include "version.h"
+#include "tnfsd.h"
+
+void tnfsd_init()
+{
+	tnfs_init();              /* initialize structures etc. */
+	tnfs_init_errtable();     /* initialize error lookup table */
+}
+
+int tnfsd_start(const char* path, int port, bool read_only)
+{
+	LOG("Starting tnfsd version %s on port %d using root directory \"%s\"\n", version, port, path);
+    if (read_only)
+    {
+        LOG("The server runs in read-only mode. TNFS clients can only list and download files.\n");
+    }
+    else
+    {
+        LOG("The server runs in read-write mode. TNFS clients can upload and modify files. Use -r to enable read-only mode.\n");
+    }
+
+    if (tnfs_setroot(path) < 0)
+    {
+		LOG("Invalid root directory: %s\n", path);
+        return TNFSD_ERR_INVALID_DIR;
+    }
+	tnfs_event_init();        /* initialize event system */
+	if (tnfs_sockinit(port) < 0)  /* initialize communications */
+    {
+        LOG("Can't bind port %d\n", port);
+        return TNFSD_ERR_SOCKET_ERROR;
+    }      
+	auth_init(read_only);     /* initialize authentication */
+	tnfs_mainloop();          /* run */
+    tnfs_event_close();
+    return 0;
+}
+
+void tnfsd_stop()
+{
+    LOG("Stopping tnfsd server.\n");
+    tnfs_sockclose();
+}

--- a/src/tnfsd.h
+++ b/src/tnfsd.h
@@ -1,0 +1,13 @@
+#ifndef _TNFSD_H
+#define _TNFSD_H
+
+#include <stdbool.h>
+
+#define TNFSD_ERR_INVALID_DIR -1
+#define TNFSD_ERR_SOCKET_ERROR -2
+
+void tnfsd_init();
+int tnfsd_start(const char* path, int port, bool read_only);
+void tnfsd_stop();
+
+#endif

--- a/src/tnfsd.h
+++ b/src/tnfsd.h
@@ -2,12 +2,27 @@
 #define _TNFSD_H
 
 #include <stdbool.h>
+#include <stdio.h>
 
 #define TNFSD_ERR_INVALID_DIR -1
 #define TNFSD_ERR_SOCKET_ERROR -2
 
+// Initialize the TNFS server. Should be called once before
+// the server can be started.
 void tnfsd_init();
+
+// Initialize the logging subsystem to use the specified
+// file descriptor. It'll use stderr by default.
+void tnfsd_init_logs(int log_output_fd);
+
+// Start the TNFS server. The function will block until
+// the server is stopped with tnfsd_stop().
+//
+// In case of an error, it'll return immediate a negative
+// value (see TNFSD_ERR_* constants).
 int tnfsd_start(const char* path, int port, bool read_only);
+
+// Stop the TNFS server and deallocate memory.
 void tnfsd_stop();
 
 #endif

--- a/src/version.h
+++ b/src/version.h
@@ -1,0 +1,6 @@
+#ifndef _VERSION_H
+#define _VERSION_H
+
+const char *version = "25.0111.1-dev";
+
+#endif


### PR DESCRIPTION
New `tnfsd_*` functions can be used to initialize, start and stop server. Server can be started and stopped multiple times within a single process. `exit()` calls in the codebase have been replaced with <0 status returned from the appropriate functions and passed to the `tnfsd.c`.

Logging can be configured to redirect messages to any file descriptor.

A proper SIGINT handler has been added, to stop the server gracefully on ^C.

Changes had been tested on Windows, macOS and Linux (Docker).