### PR TITLE
Add Atari mode with binload wrapper

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@
 /tnfsd.exe
 bin/tnfsd.exe
 /data
+src/atari_bootsector.bin
+src/atari_bootsector.h

--- a/src/Makefile
+++ b/src/Makefile
@@ -42,11 +42,41 @@ ifdef USAGELOG
 endif
 
 CFLAGS=$(FLAGS) $(EXFLAGS) $(LOGFLAGS) -DNEED_ERRTABLE
-OBJS=main.o datagram.o event_common.o log.o session.o endian.o directory.o errortable.o tnfs_file.o chroot.o fileinfo.o stats.o auth.o traverse.o match.o tnfsd.o $(EXOBJS)
+OBJS=main.o datagram.o event_common.o log.o session.o endian.o directory.o errortable.o tnfs_file.o chroot.o fileinfo.o stats.o auth.o traverse.o match.o tnfsd.o atari.o $(EXOBJS)
+
+# Check if boot sector assembly source exists
+ATARI_BOOT_ASM := $(wildcard atari-boot-xex-file.asm)
+ifneq ($(ATARI_BOOT_ASM),)
+    # Check if xa assembler is available
+    XA := $(shell which xa 2>/dev/null)
+    ifneq ($(XA),)
+        CFLAGS += -DATARI_BOOTSECTOR_EXISTS
+        ATARI_BOOT_EXISTS := yes
+    else
+        $(error xa assembler not found but $(ATARI_BOOT_ASM) exists. Install xa: brew install xa (macOS) or apt-get install xa65 (Linux))
+    endif
+endif
 
 all:	$(OBJS)
 	$(CC) -o ../bin/$(EXEC) $(OBJS) $(LIBS)
 
+# Assemble boot sector from assembly source
+atari_bootsector.bin: atari-boot-xex-file.asm
+	@echo "Assembling Atari boot sector from assembly source..."
+	xa -o atari_bootsector.bin atari-boot-xex-file.asm
+
+# Auto-generate boot sector header from binary
+atari_bootsector.h: atari_bootsector.bin
+	@echo "Converting Atari boot sector binary to header..."
+	xxd -i atari_bootsector.bin > atari_bootsector.h
+
+# atari.o depends on the generated header (if boot sector source exists)
+ifeq ($(ATARI_BOOT_EXISTS),yes)
+atari.o: atari.c atari.h atari_bootsector.h
+else
+atari.o: atari.c atari.h
+endif
+
 clean:
-	$(RM) -f $(OBJS) bin/$(EXEC)
+	$(RM) -f $(OBJS) atari_bootsector.bin atari_bootsector.h bin/$(EXEC)
 

--- a/src/atari-boot-xex-file.asm
+++ b/src/atari-boot-xex-file.asm
@@ -1,0 +1,158 @@
+	;; Atari Boot XEX File
+	;;
+	;; Does a binary load starting at the next sector
+	;; Just raw sectors; detect end when address is 0000
+	;;
+	;; This uses 0100-017F as the sector buffer (the bottom of the stack)
+	;; The code is in page 4.  Hopefully this will minimize conflicts.
+	;;
+	;; Copyright (c) 2026 Preston Crow
+	;; Released under the same licensing as tnfsd
+	;; 
+;System equates used
+	BOOT	= $09
+	FMSZPG	= $43
+	COLDST	= $0244
+	RUNAD	= $02E0
+	INITAD	= $02E2
+	DBUF	= $0304		; word
+	DBUFHI	= $0305
+	DAUX1	= $030A		; sector number
+	DAUX2	= $030B
+	BASICF	= $03F8
+	PORTB	= $D301
+	COLDSV	= $E477
+;End of system equates
+;Zero-page equates
+;End of zero-page equates
+	;; Local equates
+	LOADAT  = FMSZPG
+	LOADEND = FMSZPG+2
+	SAVEX	= FMSZPG+4
+	SECBUF  = $0100
+	START	= $0700		; Note - Didn't work at $0400
+	*= START
+	;; boot sector header
+	.byte $00 ;dos flag
+	.byte CODESECTORS
+	.byte START&255,START/256
+	.byte COLDSV&255,COLDSV/256 ; DOSINI vector on warm start (coldstart)
+	;; code starts executing here
+	;; disable BASIC
+	LDA PORTB
+	ORA #$02
+	STA PORTB
+	LDA #$01
+	STA BASICF	; BASIC shadow register (any non-zero disables on reset)
+	STA BOOT	; 1 indicates disk boot (will trigger DOSINI on warm boot)
+	;; Start binary load
+	INC DAUX1
+	LDX #$80	; Bytes read in current sector; force new sector read on next getbyte
+	LDA #SECBUF/256
+	STA DBUF+1
+	LDA #SECBUF & 255
+	STA DBUF
+	;; Get load/end address, skipping $FFFF header if any
+GETADR	JSR GETBYTE
+	STA LOADAT
+	JSR GETBYTE
+	STA LOADAT+1
+	AND LOADAT
+	CMP #$FF	; Are both bytes FF
+	BEQ GETADR
+	JSR GETBYTE
+	STA LOADEND
+	JSR GETBYTE
+	STA LOADEND+1
+	ORA LOADEND
+	BEQ DONE	; End address 0000
+	;; Increment LOADEND by 1 to point past the last byte (makes comparisons simpler)
+	INC LOADEND
+	BNE GETDATA
+	INC LOADEND+1
+	;; Now load bytes from LOADAT to LOADEND (LOADEND is now exclusive)
+GETDATA JSR FULLSEC
+	BCC CHKDONE	; Check if block is done
+	JSR GETBYTE	; Need to read byte-by-byte
+	LDY #$00
+	STA (LOADAT),Y
+	;; Increment the loadat address
+	INC LOADAT
+	BNE CHKDONE
+	INC LOADAT+1
+	BEQ BLKDONE	; error - past $FFFF, force end of block; bad things are happening
+	;; Check if this was the last byte in the block
+CHKDONE	LDA LOADEND+1
+	CMP LOADAT+1
+	BNE GETDATA
+	LDA LOADEND
+	CMP LOADAT
+	BNE GETDATA	; nope - get more data
+	;; Check if init is set
+BLKDONE	LDA INITAD
+	ORA INITAD+1
+	BEQ GETADR	; no init routine - next memory block
+	STX SAVEX
+	JSR DOINIT
+	LDX SAVEX
+	LDY #$00
+	STY INITAD
+	STY INITAD+1
+	BEQ GETADR	; unconditional branch to next memory block
+DOINIT:	JMP (INITAD)	; no JSR indirect instruction
+DONE:	JMP (RUNAD)	; hope this was set
+	;; Read one byte of data, reloading buffer from disk if needed
+GETBYTE CPX #$80
+	BNE SAMESEC
+READSEC	JSR $E453
+	BMI READSEC	; error - keep re-reading
+	;; set next sector - current sector + 1
+RSDONE	INC DAUX1
+	BNE HISECOK
+	INC DAUX2
+HISECOK	LDX #$00 	; byte offset into buffer
+	STX COLDST	; do not reboot on reset (here to save two bytes)
+SAMESEC LDA SECBUF,X
+	INX
+	RTS
+	;; Try to read a full sector into the target location directly
+FULLSEC CPX #$80
+	BNE NOFULL
+	SEC
+	LDA LOADEND
+	SBC LOADAT
+	BMI DOFULL	; >= 128 bytes left to load
+	LDA LOADEND+1
+	SBC LOADAT+1
+	BNE DOFULL	; >= 256 bytes left to load
+NOFULL	SEC
+	RTS
+DOFULL	LDA LOADAT	; switch to direct sector load
+	STA DBUF
+	LDA LOADAT+1
+	STA DBUF+1
+READSC2	JSR $E453
+	BMI READSC2	; error - keep re-reading
+	LDX #$80	; restore value - next byte requires another full sector
+	INC DAUX1
+	BNE HISECOK2
+	INC DAUX2
+HISECOK2:
+	LDA #SECBUF & 255 ; back to regular buffer (this will be LDA #00)
+	STA DBUF
+	LDA #SECBUF/256
+	STA DBUF+1
+	;; Update LOADAT
+	CLC
+	LDA LOADAT
+	ADC #$80
+	STA LOADAT
+	BCC NOHILA
+	INC LOADAT+1
+NOHILA:
+	CLC	
+	RTS
+	END = *
+	CODESIZE = END - START
+	CODESECTORS = (CODESIZE + 127) / 128
+;	.END      

--- a/src/atari.c
+++ b/src/atari.c
@@ -1,0 +1,382 @@
+/* The MIT License
+ *
+ * Copyright (c) 2026
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * Atari binary file virtualization as ATR disk images
+ *
+ * */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <strings.h>
+#include <unistd.h>
+#include <fcntl.h>
+#include <errno.h>
+#include <ctype.h>
+
+#include "atari.h"
+#include "tnfs.h"
+#include "config.h"
+
+/* Module-private global state */
+static bool atari_enabled = false;
+
+/* Boot sector data (generated from atari_bootsector.bin) */
+#ifdef ATARI_BOOTSECTOR_EXISTS
+#include "atari_bootsector.h"
+#else
+/* Placeholder: empty boot sectors if no binary provided */
+static const unsigned char atari_bootsector_bin[128] = {0};
+static const unsigned int atari_bootsector_bin_len = 128;
+#endif
+
+/* Boot sector size - dynamically calculated, rounded up to multiple of 128 */
+size_t atari_boot_sectors_size = 0;
+
+/* Helper: Round up to nearest multiple of 128 */
+static size_t round_up_128(size_t size)
+{
+	return ((size + 127) / 128) * 128;
+}
+
+/* Helper: Generate ATR header dynamically */
+static void generate_atr_header(unsigned char *header)
+{
+	/* ATR header format (16 bytes, little-endian) */
+	header[0] = 0x96;  /* Magic number low byte */
+	header[1] = 0x02;  /* Magic number high byte */
+
+	/* Paragraphs (size in 16-byte units, excluding header) */
+	uint16_t count16 = ATR_DATA_SIZE / 16;  /* 130048 / 16 = 8128 = 0x1FC0 */
+	header[2] = count16 & 0xFF;             /* 0xC0 */
+	header[3] = (count16 >> 8) & 0xFF;      /* 0x1F */
+
+	/* Sector size (128 bytes for single density) */
+	header[4] = 0x80;  /* 128 low byte */
+	header[5] = 0x00;  /* 128 high byte */
+
+	/* High bytes of paragraph count (for >16MB images, not needed) */
+	header[6] = 0x00;
+	header[7] = 0x00;
+
+	/* Reserved/unused bytes */
+	memset(header + 8, 0, 8);
+}
+
+/* Helper: Extract file extension from path */
+static const char *get_file_extension(const char *filepath)
+{
+	const char *dot = strrchr(filepath, '.');
+	if (!dot || dot == filepath)
+		return "";
+	return dot + 1;
+}
+
+/* Helper: Check if extension is in exclusion list (case-insensitive) */
+static bool is_excluded_extension(const char *ext)
+{
+	/* FujiNet handles these natively, don't virtualize */
+	return (strcasecmp(ext, "xex") == 0 ||
+	        strcasecmp(ext, "com") == 0 ||
+	        strcasecmp(ext, "bin") == 0);
+}
+
+/* Helper: Minimum of two size_t values */
+static inline size_t min_size(size_t a, size_t b)
+{
+	return (a < b) ? a : b;
+}
+
+/* Initialize Atari module */
+void atari_init(bool enable_atari_mode)
+{
+	atari_enabled = enable_atari_mode;
+
+	/* Calculate boot sector size, rounded up to multiple of 128 bytes */
+	atari_boot_sectors_size = round_up_128(atari_bootsector_bin_len);
+
+#ifdef DEBUG
+	if (enable_atari_mode)
+	{
+		fprintf(stderr, "Atari mode initialized: boot sector file size=%u, rounded to %zu bytes\n",
+				atari_bootsector_bin_len, atari_boot_sectors_size);
+	}
+#endif
+}
+
+/* Check if Atari mode is enabled */
+bool atari_is_enabled(void)
+{
+	return atari_enabled;
+}
+
+/* Determine if a file should be virtualized as ATR
+ * Returns true if:
+ * - File is opened for reading only
+ * - Extension is NOT .xex, .com, or .bin
+ * - First two bytes are $FFFF
+ */
+bool atari_should_virtualize(const char *filepath, int flags)
+{
+	unsigned char magic[2];
+	int fd;
+	ssize_t n;
+	const char *ext;
+
+	if (!atari_enabled)
+		return false;
+
+	/* Only virtualize files opened for reading (not write/append/create) */
+	if ((flags & (O_WRONLY | O_RDWR | O_CREAT | O_APPEND)) != 0)
+		return false;
+
+	/* Check if extension is in exclusion list */
+	ext = get_file_extension(filepath);
+	if (is_excluded_extension(ext))
+		return false;
+
+	/* Open file and check magic bytes */
+	fd = open(filepath, O_RDONLY);
+	if (fd < 0)
+		return false;
+
+	/* Read first 2 bytes */
+	n = read(fd, magic, 2);
+	close(fd);
+
+	if (n != 2)
+		return false;
+
+	/* Check for $FFFF magic (Atari binary load file marker) */
+	return (magic[0] == 0xFF && magic[1] == 0xFF);
+}
+
+/* Mark a file descriptor as Atari virtual */
+void atari_mark_fd(Session *s, int tnfs_fd, off_t real_size)
+{
+	if (tnfs_fd < 0 || tnfs_fd >= MAX_FD_PER_CONN)
+		return;
+
+	s->atari_fd[tnfs_fd].is_atari_binary = true;
+	s->atari_fd[tnfs_fd].virtual_position = 0;
+	s->atari_fd[tnfs_fd].real_file_size = real_size;
+}
+
+/* Clear Atari metadata for a file descriptor */
+void atari_clear_fd(Session *s, int tnfs_fd)
+{
+	if (tnfs_fd < 0 || tnfs_fd >= MAX_FD_PER_CONN)
+		return;
+
+	s->atari_fd[tnfs_fd].is_atari_binary = false;
+	s->atari_fd[tnfs_fd].virtual_position = 0;
+	s->atari_fd[tnfs_fd].real_file_size = 0;
+}
+
+/* Check if a file descriptor is an Atari virtual file */
+bool atari_is_virtual_fd(Session *s, int tnfs_fd)
+{
+	if (tnfs_fd < 0 || tnfs_fd >= MAX_FD_PER_CONN)
+		return false;
+
+	return s->atari_fd[tnfs_fd].is_atari_binary;
+}
+
+/* Get virtual file size */
+off_t atari_get_virtual_size(Session *s, int tnfs_fd)
+{
+	if (tnfs_fd < 0 || tnfs_fd >= MAX_FD_PER_CONN)
+		return 0;
+
+	if (!s->atari_fd[tnfs_fd].is_atari_binary)
+		return 0;
+
+	return ATR_TOTAL_SIZE;
+}
+
+/* Get virtual file position */
+off_t atari_get_virtual_position(Session *s, int tnfs_fd)
+{
+	if (tnfs_fd < 0 || tnfs_fd >= MAX_FD_PER_CONN)
+		return 0;
+
+	return s->atari_fd[tnfs_fd].virtual_position;
+}
+
+/* Set virtual file position */
+void atari_set_virtual_position(Session *s, int tnfs_fd, off_t pos)
+{
+	if (tnfs_fd < 0 || tnfs_fd >= MAX_FD_PER_CONN)
+		return;
+
+	s->atari_fd[tnfs_fd].virtual_position = pos;
+}
+
+/* Virtual read operation
+ * Synthesizes data from four regions:
+ * 1. ATR header (16 bytes)
+ * 2. Boot sectors (compiled-in binary, 384 bytes)
+ * 3. Real file data (from OS file descriptor)
+ * 4. Zero padding (to reach 130KB data section)
+ */
+int atari_virtual_read(Session *s, int tnfs_fd, int os_fd,
+                       unsigned char *buf, size_t count)
+{
+	atari_fd_metadata *meta = &s->atari_fd[tnfs_fd];
+	off_t vpos = meta->virtual_position;
+	off_t virtual_size = ATR_TOTAL_SIZE;
+	size_t bytes_read = 0;
+	unsigned char atr_header[ATR_HEADER_SIZE];
+	off_t boot_end = ATR_HEADER_SIZE + atari_boot_sectors_size;
+	off_t file_start = boot_end;
+	off_t file_end = file_start + meta->real_file_size;
+
+	/* Check for EOF */
+	if (vpos >= virtual_size)
+		return 0;
+
+	/* Limit read to virtual EOF */
+	if (vpos + (off_t)count > virtual_size)
+		count = virtual_size - vpos;
+
+	/* Generate ATR header once */
+	generate_atr_header(atr_header);
+
+	/* Read from appropriate region(s) */
+	while (count > 0 && vpos < virtual_size) {
+		if (vpos < ATR_HEADER_SIZE) {
+			/* Region 1: ATR header (16 bytes) */
+			size_t header_offset = vpos;
+			size_t header_bytes = min_size(count, ATR_HEADER_SIZE - header_offset);
+			memcpy(buf, atr_header + header_offset, header_bytes);
+			buf += header_bytes;
+			vpos += header_bytes;
+			bytes_read += header_bytes;
+			count -= header_bytes;
+		}
+		else if (vpos < boot_end) {
+			/* Region 2: Boot sectors (from compiled binary, padded with zeros) */
+			size_t boot_offset = vpos - ATR_HEADER_SIZE;
+			size_t boot_bytes = min_size(count, boot_end - vpos);
+			size_t total_boot_bytes = boot_bytes;
+
+			/* Copy from actual boot sector data or zero padding */
+			if (boot_offset < atari_bootsector_bin_len) {
+				/* Still in actual boot sector data */
+				size_t actual_bytes = min_size(boot_bytes, atari_bootsector_bin_len - boot_offset);
+				memcpy(buf, atari_bootsector_bin + boot_offset, actual_bytes);
+				buf += actual_bytes;
+				boot_bytes -= actual_bytes;
+			}
+
+			/* Fill remaining with zeros (padding to round up to 128) */
+			if (boot_bytes > 0) {
+				memset(buf, 0, boot_bytes);
+				buf += boot_bytes;
+			}
+
+			vpos += total_boot_bytes;
+			bytes_read += total_boot_bytes;
+			count -= total_boot_bytes;
+		}
+		else if (vpos < file_end) {
+			/* Region 3: Actual file data */
+			off_t file_offset = vpos - file_start;
+			size_t file_bytes_available = file_end - vpos;
+			size_t file_bytes = min_size(count, file_bytes_available);
+
+			/* Seek to correct position in real file */
+			if (lseek(os_fd, file_offset, SEEK_SET) < 0) {
+				/* Seek error - return what we've read so far */
+				break;
+			}
+
+			/* Read from real file */
+			ssize_t n = read(os_fd, buf, file_bytes);
+			if (n < 0) {
+				/* Read error - return what we've read so far or error */
+				if (bytes_read == 0)
+					return -1;
+				break;
+			}
+
+			buf += n;
+			vpos += n;
+			bytes_read += n;
+			count -= n;
+
+			/* Short read from file */
+			if ((size_t)n < file_bytes)
+				break;
+		}
+		else {
+			/* Region 4: Zero padding to reach virtual size */
+			size_t pad_bytes = min_size(count, virtual_size - vpos);
+			memset(buf, 0, pad_bytes);
+			buf += pad_bytes;
+			vpos += pad_bytes;
+			bytes_read += pad_bytes;
+			count -= pad_bytes;
+		}
+	}
+
+	/* Update virtual position */
+	meta->virtual_position = vpos;
+	return bytes_read;
+}
+
+/* Virtual seek operation
+ * Updates virtual position without touching OS file descriptor
+ */
+off_t atari_virtual_lseek(Session *s, int tnfs_fd, int os_fd,
+                          off_t offset, int whence)
+{
+	atari_fd_metadata *meta = &s->atari_fd[tnfs_fd];
+	off_t virtual_size = ATR_TOTAL_SIZE;
+	off_t new_pos;
+
+	/* Calculate new virtual position based on whence */
+	switch (whence) {
+		case SEEK_SET:
+			new_pos = offset;
+			break;
+		case SEEK_CUR:
+			new_pos = meta->virtual_position + offset;
+			break;
+		case SEEK_END:
+			new_pos = virtual_size + offset;
+			break;
+		default:
+			errno = EINVAL;
+			return -1;
+	}
+
+	/* Validate position (negative is error, but seeking past EOF is allowed) */
+	if (new_pos < 0) {
+		errno = EINVAL;
+		return -1;
+	}
+
+	/* Update virtual position */
+	meta->virtual_position = new_pos;
+	return new_pos;
+}

--- a/src/atari.h
+++ b/src/atari.h
@@ -1,0 +1,82 @@
+#ifndef _ATARI_H
+#define _ATARI_H
+
+/* The MIT License
+ *
+ * Copyright (c) 2026
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * Atari binary file virtualization as ATR disk images
+ *
+ * */
+
+#include <stdbool.h>
+#include <stdint.h>
+#include <sys/types.h>
+
+/* ATR disk image constants */
+#define ATR_HEADER_SIZE 16
+#define ATR_DATA_SIZE 256*1024  /* Virtual image size for binary load files */
+#define ATR_TOTAL_SIZE (ATR_HEADER_SIZE + ATR_DATA_SIZE)
+
+/* Boot sector size is determined dynamically at runtime from the actual file */
+extern size_t atari_boot_sectors_size;
+
+/* ATR file header format (16 bytes) */
+struct atr_head {
+	unsigned char h0;              /* 0x96 - Magic byte */
+	unsigned char h1;              /* 0x02 - Magic byte */
+	unsigned char bytes16count[2]; /* Size in paragraphs (16-byte units): 130048/16 = 8128 */
+	unsigned char secsize[2];      /* Sector size: 128 (0x80, 0x00) */
+	unsigned char hibytes16count[2]; /* High word of paragraph count (for >16MB images) */
+	unsigned char unused[8];       /* Reserved, set to zero */
+};
+
+/* Forward declarations */
+struct _session;
+typedef struct _session Session;
+/* atari_fd_metadata is fully defined in tnfs.h - no need to redeclare */
+
+/* Module initialization */
+void atari_init(bool enable_atari_mode);
+
+/* Check if Atari mode is enabled */
+bool atari_is_enabled(void);
+
+/* File detection and setup */
+bool atari_should_virtualize(const char *filepath, int flags);
+void atari_mark_fd(Session *s, int tnfs_fd, off_t real_size);
+void atari_clear_fd(Session *s, int tnfs_fd);
+
+/* Virtual file operations */
+bool atari_is_virtual_fd(Session *s, int tnfs_fd);
+off_t atari_get_virtual_size(Session *s, int tnfs_fd);
+off_t atari_get_virtual_position(Session *s, int tnfs_fd);
+void atari_set_virtual_position(Session *s, int tnfs_fd, off_t pos);
+
+/* Virtual read operation */
+int atari_virtual_read(Session *s, int tnfs_fd, int os_fd,
+                       unsigned char *buf, size_t count);
+
+/* Virtual seek operation */
+off_t atari_virtual_lseek(Session *s, int tnfs_fd, int os_fd,
+                          off_t offset, int whence);
+
+#endif

--- a/src/main.c
+++ b/src/main.c
@@ -49,13 +49,14 @@ int main(int argc, char **argv)
     char *gvalue = NULL;
 #endif
     bool read_only = false;
+    bool atari_mode = false;
     char *pvalue = NULL;
     char *root_path = NULL;
 
     #ifdef ENABLE_CHROOT
-    while((opt = getopt(argc, argv, "ru:g:p:")) != -1)
+    while((opt = getopt(argc, argv, "aru:g:p:")) != -1)
     #else
-    while((opt = getopt(argc, argv, "rp:")) != -1)
+    while((opt = getopt(argc, argv, "arp:")) != -1)
     #endif
     {
         switch(opt)
@@ -65,6 +66,9 @@ int main(int argc, char **argv)
                 break;
             case 'r':
                 read_only = true;
+                break;
+            case 'a':
+                atari_mode = true;
                 break;
             #ifdef ENABLE_CHROOT
             case 'u':
@@ -140,7 +144,7 @@ int main(int argc, char **argv)
     tnfsd_init();
     tnfsd_init_logs(STDERR_FILENO);
     signal(SIGINT, tnfsd_stop);
-    tnfsd_start(root_path, port, read_only);
+    tnfsd_start(root_path, port, read_only, atari_mode);
 
     return 0;
 }
@@ -148,8 +152,10 @@ int main(int argc, char **argv)
 void print_usage()
 {
     #ifdef ENABLE_CHROOT
-    fprintf(stderr, "Usage: tnfsd [-u <username> -g <group> -p <port> -r] <root dir>\n");
+    fprintf(stderr, "Usage: tnfsd [-u <username> -g <group> -p <port> -r -a] <root dir>\n");
+    fprintf(stderr, "  -a  Enable Atari mode (present binary files as ATR images)\n");
     #else
-    fprintf(stderr, "Usage: tnfsd [-p <port> -r] <root dir>\n");
+    fprintf(stderr, "Usage: tnfsd [-p <port> -r -a] <root dir>\n");
+    fprintf(stderr, "  -a  Enable Atari mode (present binary files as ATR images)\n");
     #endif
 }

--- a/src/tnfs.h
+++ b/src/tnfs.h
@@ -138,6 +138,13 @@ typedef struct _dir_handle
 	int ignore_count;
 } dir_handle;
 
+/* Forward declare atari_fd_metadata for use in Session struct */
+typedef struct {
+	bool is_atari_binary;
+	off_t virtual_position;
+	off_t real_file_size;
+} atari_fd_metadata;
+
 typedef struct _session
 {
 	time_t last_contact; /* timestamp of last received request */
@@ -145,6 +152,7 @@ typedef struct _session
 	in_addr_t ipaddr;		/* client addr */
 	uint8_t seqno;			/* last sequence number */
 	int fd[MAX_FD_PER_CONN];	/* file descriptors */
+	atari_fd_metadata atari_fd[MAX_FD_PER_CONN]; /* Atari virtualization metadata */
 	//DIR *dhnd[MAX_DHND_PER_CONN];	/* directory handles */
 	//char dpaths[MAX_DHND_PER_CONN][MAX_TNFSPATH]; /* directory path for each handle */
 	dir_handle dhandles[MAX_DHND_PER_CONN];

--- a/src/tnfs_file.c
+++ b/src/tnfs_file.c
@@ -52,6 +52,7 @@
 #include "bsdcompat.h"
 #include "log.h"
 #include "auth.h"
+#include "atari.h"
 
 char fnbuf[MAX_FILEPATH];
 unsigned char iobuf[MAX_IOSZ + 2]; /* 2 bytes added for the size param */
@@ -132,6 +133,20 @@ void tnfs_open(Header *hdr, Session *s, unsigned char *buf, int bufsz)
 				return;
 			}
 
+			/* Check if Atari virtualization should be enabled for this file */
+			if (atari_is_enabled() && atari_should_virtualize(fnbuf, tnfs_make_mode(flags)))
+			{
+				struct stat st;
+				if (fstat(fd, &st) == 0)
+				{
+					atari_mark_fd(s, i, st.st_size);
+#ifdef DEBUG
+					fprintf(stderr, "Atari mode: virtualizing %s as ATR (real size: %lld)\n",
+							fnbuf, (long long)st.st_size);
+#endif
+				}
+			}
+
 			s->fd[i] = fd;
 			hdr->status = TNFS_SUCCESS;
 			reply[0] = (unsigned char)i;
@@ -156,7 +171,17 @@ void tnfs_read(Header *hdr, Session *s, unsigned char *buf, int bufsz)
 	requestsz = tnfs16uint(buf + 1);
 	if (requestsz > MAX_IOSZ)
 		requestsz = MAX_IOSZ;
-	readsz = read(fd, iobuf + 2, (size_t)requestsz);
+
+	/* Check if this is an Atari virtual file */
+	if (atari_is_virtual_fd(s, *buf))
+	{
+		readsz = atari_virtual_read(s, *buf, fd, iobuf + 2, (size_t)requestsz);
+	}
+	else
+	{
+		readsz = read(fd, iobuf + 2, (size_t)requestsz);
+	}
+
 	if (readsz > 0)
 	{
 		hdr->status = TNFS_SUCCESS;
@@ -230,7 +255,18 @@ void tnfs_lseek(Header *hdr, Session *s, unsigned char *buf, int bufsz)
 	fprintf(stderr, "lseek: offset=%d (%x) whence=%d tnfs_whence=%d\n",
 			offset, offset, whence, *(buf + 1));
 #endif
-	if ((result = lseek(fd, (off_t)offset, whence)) < 0)
+
+	/* Check if this is an Atari virtual file */
+	if (atari_is_virtual_fd(s, *buf))
+	{
+		result = atari_virtual_lseek(s, *buf, fd, (off_t)offset, whence);
+	}
+	else
+	{
+		result = lseek(fd, (off_t)offset, whence);
+	}
+
+	if (result < 0)
 	{
 		hdr->status = tnfs_error(errno);
 #ifdef DEBUG
@@ -258,6 +294,12 @@ void tnfs_close(Header *hdr, Session *s, unsigned char *buf, int bufsz)
 
 	if (close(fd) == 0)
 	{
+		/* Clear Atari metadata if present */
+		if (atari_is_enabled())
+		{
+			atari_clear_fd(s, *buf);
+		}
+
 		s->fd[*buf] = 0; /* clear the session's descriptor */
 		hdr->status = TNFS_SUCCESS;
 		tnfs_send(s, hdr, NULL, 0);
@@ -297,7 +339,19 @@ void tnfs_stat(Header *hdr, Session *s, unsigned char *buf, int bufsz)
 		uint16tnfs(msgbuf + ST_MODE_OFFSET, (uint16_t)statinfo.st_mode);
 		uint16tnfs(msgbuf + ST_UID_OFFSET, (uint16_t)statinfo.st_uid);
 		uint16tnfs(msgbuf + ST_GID_OFFSET, (uint16_t)statinfo.st_gid);
-		uint32tnfs(msgbuf + ST_SIZE_OFFSET, (uint32_t)statinfo.st_size);
+
+		/* Check if this file would be virtualized as Atari ATR */
+		uint32_t report_size = (uint32_t)statinfo.st_size;
+		if (atari_is_enabled() && atari_should_virtualize(fnbuf, O_RDONLY))
+		{
+			report_size = ATR_TOTAL_SIZE;
+#ifdef DEBUG
+			fprintf(stderr, "stat: Reporting virtual ATR size %u instead of real size %lld\n",
+					report_size, (long long)statinfo.st_size);
+#endif
+		}
+		uint32tnfs(msgbuf + ST_SIZE_OFFSET, report_size);
+
 		uint32tnfs(msgbuf + ST_ATIME_OFFSET, (uint32_t)statinfo.st_atime);
 		uint32tnfs(msgbuf + ST_MTIME_OFFSET, (uint32_t)statinfo.st_mtime);
 		uint32tnfs(msgbuf + ST_CTIME_OFFSET, (uint32_t)statinfo.st_ctime);

--- a/src/tnfsd.c
+++ b/src/tnfsd.c
@@ -1,5 +1,6 @@
 #include <stdio.h>
 
+#include "atari.h"
 #include "auth.h"
 #include "datagram.h"
 #include "directory.h"
@@ -21,7 +22,7 @@ void tnfsd_init_logs(int log_output_fd)
 	log_init(log_output);
 }
 
-int tnfsd_start(const char* path, int port, bool read_only)
+int tnfsd_start(const char* path, int port, bool read_only, bool atari_mode)
 {
 	LOG("Starting tnfsd version %s on port %d using root directory \"%s\"\n", version, port, path);
 	if (read_only)
@@ -31,6 +32,10 @@ int tnfsd_start(const char* path, int port, bool read_only)
 	else
 	{
 		LOG("The server runs in read-write mode. TNFS clients can upload and modify files. Use -r to enable read-only mode.\n");
+	}
+	if (atari_mode)
+	{
+		LOG("Atari mode enabled: Binary files ($FFFF) will be presented as ATR disk images.\n");
 	}
 
 	if (tnfs_setroot(path) < 0)
@@ -43,8 +48,9 @@ int tnfsd_start(const char* path, int port, bool read_only)
 	{
 		LOG("Can't bind port %d\n", port);
 		return TNFSD_ERR_SOCKET_ERROR;
-	}      
+	}
 	auth_init(read_only);     /* initialize authentication */
+	atari_init(atari_mode);   /* initialize Atari virtualization */
 	tnfs_mainloop();          /* run */
 	tnfs_event_close();
 	return 0;

--- a/src/tnfsd.h
+++ b/src/tnfsd.h
@@ -20,7 +20,7 @@ void tnfsd_init_logs(int log_output_fd);
 //
 // In case of an error, it'll return immediate a negative
 // value (see TNFSD_ERR_* constants).
-int tnfsd_start(const char* path, int port, bool read_only);
+int tnfsd_start(const char* path, int port, bool read_only, bool atari_mode);
 
 // Stop the TNFS server and deallocate memory.
 void tnfsd_stop(int sig);


### PR DESCRIPTION
Adds Atari mode (`--atari` flag) that virtualizes Atari binary files that won't be recognized by FujiNet as bootable ATR disk images.

This change:
- Detects Atari binaries by checking for $FFFF magic bytes
- Excludes .xex, .com, and .bin files (handled natively by FujiNet)
- Virtualizes detected files as 133,136-byte ATR disk images with:
  - Dynamic ATR header
  - Boot sectors that disable BASIC
  - Original file contents
  - Zero padding to 130KB

The boot sector can be customized by editing `src/atari-boot-xex-file.asm` (requires `xa` assembler).