### PR TITLE
Make ENABLE_CHROOT optional and allow symlinks when disabled

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -15,7 +15,7 @@ ifndef OS
 endif
 
 ifeq ($(OS),LINUX)
-    FLAGS = -Wall -DUNIX -DNEED_BSDCOMPAT -DENABLE_CHROOT 
+    FLAGS = -Wall -DUNIX -DNEED_BSDCOMPAT
     EXOBJS = strlcpy.o strlcat.o event_epoll.o 
     LIBS =
     EXEC = tnfsd
@@ -27,10 +27,23 @@ ifeq ($(OS),Windows_NT)
     EXEC = tnfsd.exe
 endif
 ifeq ($(OS),BSD)
-    FLAGS = -Wall -DUNIX -DBSD -DENABLE_CHROOT
+    FLAGS = -Wall -DUNIX -DBSD
     EXOBJS = event_kqueue.o
     LIBS =
     EXEC = tnfsd
+endif
+
+# ENABLE_CHROOT defaults to yes on Unix systems for security
+# Disable with: make ENABLE_CHROOT=no
+ifeq ($(OS),LINUX)
+    ENABLE_CHROOT ?= yes
+endif
+ifeq ($(OS),BSD)
+    ENABLE_CHROOT ?= yes
+endif
+
+ifeq ($(ENABLE_CHROOT),yes)
+    CHROOTFLAGS = -DENABLE_CHROOT
 endif
 
 ifdef DEBUG
@@ -41,7 +54,7 @@ ifdef USAGELOG
     LOGFLAGS = -DUSAGELOG
 endif
 
-CFLAGS=$(FLAGS) $(EXFLAGS) $(LOGFLAGS) -DNEED_ERRTABLE
+CFLAGS=$(FLAGS) $(EXFLAGS) $(LOGFLAGS) $(CHROOTFLAGS) -DNEED_ERRTABLE
 OBJS=main.o datagram.o event_common.o log.o session.o endian.o directory.o errortable.o tnfs_file.o chroot.o fileinfo.o stats.o auth.o traverse.o match.o tnfsd.o $(EXOBJS)
 
 all:	$(OBJS)

--- a/src/directory.c
+++ b/src/directory.c
@@ -283,6 +283,9 @@ void get_root(Session *s, char *buf, int bufsz)
    Returns 0 if path is outside tnfs root */
 int validate_path(Session *s, const char *path)
 {
+#if defined(UNIX) && !defined(ENABLE_CHROOT)
+	return 1; // Always allow symlinks when we're intentionally avoiding chroot
+#else
 	char valpath[MAX_FILEPATH];
 
 #ifdef WIN32
@@ -309,6 +312,7 @@ int validate_path(Session *s, const char *path)
 #endif
 		return 0;
 	}
+#endif
 }
 
 /* normalize paths, remove multiple delimiters


### PR DESCRIPTION
Makes the `ENABLE_CHROOT` compile flag configurable via the Makefile while keeping it enabled by default for security.

**Changes:**
- `ENABLE_CHROOT` now defaults to `yes` on Unix systems but can be disabled with `make ENABLE_CHROOT=no`
- When chroot is explicitly disabled, symlinks that point outside the TNFS root are allowed
- Path validation is bypassed when running without chroot (for development/testing scenarios)

**Rationale:**
The previous behavior always enabled chroot on Unix systems and validated all paths to prevent symlinks from escaping the root directory. This is important for security in production environments, but can be restrictive for development and testing where following symlinks outside the root is intentional.

This change maintains the secure-by-default behavior while providing flexibility for non-production use cases.

**Usage:**
```bash
make ENABLE_CHROOT=no    # Allows symlinks outside root
make                      # Default: chroot enabled (secure)
```